### PR TITLE
Timer for each round

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,7 @@ function App() {
                 {game.newGame.players.map((player: Player) => (
                     <Character
                         key={player.playerId}
+                        playerName={game.players[player.playerId].displayName}
                         player={player}
                     />
                 ))}

--- a/src/components/Character.tsx
+++ b/src/components/Character.tsx
@@ -38,10 +38,10 @@ const Body: React.FC<BodyProps> = ({ children, player }) => {
     );
 };
 
-export const Character: React.FC<CharacterProps> = ({ player }) => {
+export const Character: React.FC<CharacterProps> = ({ playerName, player }) => {
     return (
         <div className="relative flex flex-col items-center w-full p-4 bg-black/10 rounded-3xl aspect-square">
-            <span>{player.displayName}</span>
+            <span>{playerName}</span>
             <span className="absolute top-0 right-0 font-black stroke-text">{player.score}</span>
             <Body player={player}>
                 <Limb

--- a/src/components/RoundTimer.tsx
+++ b/src/components/RoundTimer.tsx
@@ -28,7 +28,7 @@ export const RoundTimer: React.FC<RoundTimerProps> = ({ setRoundTimeUp }) => {
     <>
       <div className="w-full h-10 py-2">
         <div
-          className="h-full bg-white"
+          className="h-full bg-white transition-all rounded-xl"
           style={{ width: `${(progress%6 / 5) * 100}%` }} // Calculate the width based on the progress
         />
       </div>

--- a/src/components/RoundTimer.tsx
+++ b/src/components/RoundTimer.tsx
@@ -4,11 +4,16 @@ import { RoundTimerProps } from "../types/types";
 export const RoundTimer: React.FC<RoundTimerProps> = ({
   game,
   scoreAndTurnCard,
-  activeCardIndex
+  activeCardIndex,
 }) => {
-  const INTERVAL = 6 // THIS IS THE AMOUNT OF TIME IN A ROUND, IN SECONDS
-  const gameTimerProgress = (60 - game.newGame.remainingTime) % INTERVAL;
+  const INTERVAL = 6; // THIS IS THE AMOUNT OF TIME IN A ROUND, IN SECONDS
+  const gameTimerProgress = (60 - game.newGame.remainingTime);
   const [progress, setProgress] = useState<number>(gameTimerProgress);
+  const [roundNumber, setRoundNumber] = useState<number>(1);
+
+  useEffect(()=> {
+    console.log(game)
+  }, [])
 
   useEffect(() => {
     // ENSURES THE ROUND TIMER STAYS IN SYNC WITH GAME TIMER
@@ -16,28 +21,44 @@ export const RoundTimer: React.FC<RoundTimerProps> = ({
 
     // INCREMENT PROGRESS BAR EVERY SECOND
     const interval = setInterval(() => {
-      setProgress((prevProgress) => (prevProgress + 1) % INTERVAL);
+      setProgress((prevProgress) => (prevProgress + 1));
+      if (progress > 59) {
+        clearInterval(interval)
+      }
     }, 1000); // Increment progress every second
-
     return () => clearInterval(interval);
   }, [gameTimerProgress, progress]);
 
   useEffect(() => {
-    // IF THE ROUND TIMER BAR IS STARTING OVER (and it's not just because the timer was at 0)
+    // IF THE ROUND TIMER BAR IS STARTING OVER
     // THEN SCORE & TURN THE NEXT CARD OVER
-    if (progress === 0 && game.newGame.remainingTime < 59) {
+    if (
+      progress % INTERVAL === 0 &&
+      progress < 59 && 
+      progress > 0
+    ) {
       Rune.actions.checkPlayerPoses({ index: activeCardIndex });
       scoreAndTurnCard();
+      setRoundNumber((prev) => prev + 1);
     }
   }, [progress]);
+
+  useEffect(() => {
+    // SCORE THE LAST ROUND A SECOND EARLY so gameOver doesn't interfere... may change later
+    if (roundNumber === 10 && game.newGame.remainingTime === 1) {
+      Rune.actions.checkPlayerPoses({ index: activeCardIndex });
+    }
+  }, [roundNumber, game.newGame.remainingTime]);
 
   return (
     <>
       <div className="w-full h-10 py-2">
         <div
-          className="h-full bg-white transition-all rounded-xl"
-          style={{ width: `${((progress % INTERVAL) / (INTERVAL-1)) * 100}%` }} // Calculate the width based on the progress
-        />
+          className="h-full bg-white transition-all rounded-xl font-bold"
+          style={{
+            width: `${((progress % INTERVAL) / (INTERVAL - 1)) * 100}%`,
+          }} // Calculate the width based on the progress
+        >{progress}</div>
       </div>
     </>
   );

--- a/src/components/RoundTimer.tsx
+++ b/src/components/RoundTimer.tsx
@@ -7,13 +7,13 @@ export const RoundTimer: React.FC<RoundTimerProps> = ({
   activeCardIndex,
 }) => {
   const INTERVAL = 6; // THIS IS THE AMOUNT OF TIME IN A ROUND, IN SECONDS
-  const gameTimerProgress = (60 - game.newGame.remainingTime);
+  const gameTimerProgress = 60 - game.newGame.remainingTime;
   const [progress, setProgress] = useState<number>(gameTimerProgress);
   const [roundNumber, setRoundNumber] = useState<number>(1);
 
-  useEffect(()=> {
-    console.log(game)
-  }, [])
+  // useEffect(() => {
+  //   console.log(game);
+  // }, []);
 
   useEffect(() => {
     // ENSURES THE ROUND TIMER STAYS IN SYNC WITH GAME TIMER
@@ -21,9 +21,9 @@ export const RoundTimer: React.FC<RoundTimerProps> = ({
 
     // INCREMENT PROGRESS BAR EVERY SECOND
     const interval = setInterval(() => {
-      setProgress((prevProgress) => (prevProgress + 1));
+      setProgress((prevProgress) => prevProgress + 1);
       if (progress > 59) {
-        clearInterval(interval)
+        clearInterval(interval);
       }
     }, 1000); // Increment progress every second
     return () => clearInterval(interval);
@@ -32,11 +32,7 @@ export const RoundTimer: React.FC<RoundTimerProps> = ({
   useEffect(() => {
     // IF THE ROUND TIMER BAR IS STARTING OVER
     // THEN SCORE & TURN THE NEXT CARD OVER
-    if (
-      progress % INTERVAL === 0 &&
-      progress < 59 && 
-      progress > 0
-    ) {
+    if (progress % INTERVAL === 0 && progress < 59 && progress > 0) {
       Rune.actions.checkPlayerPoses({ index: activeCardIndex });
       scoreAndTurnCard();
       setRoundNumber((prev) => prev + 1);
@@ -58,7 +54,8 @@ export const RoundTimer: React.FC<RoundTimerProps> = ({
           style={{
             width: `${((progress % INTERVAL) / (INTERVAL - 1)) * 100}%`,
           }} // Calculate the width based on the progress
-        >{progress}</div>
+        />
+        {/* >{progress}</div> */}
       </div>
     </>
   );

--- a/src/components/RoundTimer.tsx
+++ b/src/components/RoundTimer.tsx
@@ -1,35 +1,42 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState } from "react";
+import { RoundTimerProps } from "../types/types";
 
-type RoundTimerProps = {
-    setRoundTimeUp:React.Dispatch<React.SetStateAction<boolean>>;
-}
-
-export const RoundTimer: React.FC<RoundTimerProps> = ({ setRoundTimeUp }) => {
-  const [progress, setProgress] = useState(0);
+export const RoundTimer: React.FC<RoundTimerProps> = ({
+  game,
+  scoreAndTurnCard,
+  activeCardIndex
+}) => {
+  const INTERVAL = 6 // THIS IS THE AMOUNT OF TIME IN A ROUND, IN SECONDS
+  const gameTimerProgress = (60 - game.newGame.remainingTime) % INTERVAL;
+  const [progress, setProgress] = useState<number>(gameTimerProgress);
 
   useEffect(() => {
-    /////////   PLACEHOLDER   ///////////////
-    // This is just a placeholder to start the timer
-    const interval = setInterval(() => {
-      setProgress((prevProgress) => prevProgress + 1);
-    }, 1000); // Increment progress every second
-    return () => clearInterval(interval);
-  }, []);
+    // ENSURES THE ROUND TIMER STAYS IN SYNC WITH GAME TIMER
+    setProgress(gameTimerProgress);
 
-  useEffect(()=> {
-    let progressPercent = (progress%6 / 5) * 100
-    if (progressPercent == 100){
-        setRoundTimeUp(true)
+    // INCREMENT PROGRESS BAR EVERY SECOND
+    const interval = setInterval(() => {
+      setProgress((prevProgress) => (prevProgress + 1) % INTERVAL);
+    }, 1000); // Increment progress every second
+
+    return () => clearInterval(interval);
+  }, [gameTimerProgress, progress]);
+
+  useEffect(() => {
+    // IF THE ROUND TIMER BAR IS STARTING OVER (and it's not just because the timer was at 0)
+    // THEN SCORE & TURN THE NEXT CARD OVER
+    if (progress === 0 && game.newGame.remainingTime < 59) {
+      Rune.actions.checkPlayerPoses({ index: activeCardIndex });
+      scoreAndTurnCard();
     }
-    // setRoundTimeUp(false)
-  }, [progress])
+  }, [progress]);
 
   return (
     <>
       <div className="w-full h-10 py-2">
         <div
           className="h-full bg-white transition-all rounded-xl"
-          style={{ width: `${(progress%6 / 5) * 100}%` }} // Calculate the width based on the progress
+          style={{ width: `${((progress % INTERVAL) / (INTERVAL-1)) * 100}%` }} // Calculate the width based on the progress
         />
       </div>
     </>

--- a/src/components/RoundTimer.tsx
+++ b/src/components/RoundTimer.tsx
@@ -1,0 +1,37 @@
+import React, { useEffect, useState } from 'react';
+
+type RoundTimerProps = {
+    setRoundTimeUp:React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+export const RoundTimer: React.FC<RoundTimerProps> = ({ setRoundTimeUp }) => {
+  const [progress, setProgress] = useState(0);
+
+  useEffect(() => {
+    /////////   PLACEHOLDER   ///////////////
+    // This is just a placeholder to start the timer
+    const interval = setInterval(() => {
+      setProgress((prevProgress) => prevProgress + 1);
+    }, 1000); // Increment progress every second
+    return () => clearInterval(interval);
+  }, []);
+
+  useEffect(()=> {
+    let progressPercent = (progress%6 / 5) * 100
+    if (progressPercent == 100){
+        setRoundTimeUp(true)
+    }
+    // setRoundTimeUp(false)
+  }, [progress])
+
+  return (
+    <>
+      <div className="w-full h-10 py-2">
+        <div
+          className="h-full bg-white"
+          style={{ width: `${(progress%6 / 5) * 100}%` }} // Calculate the width based on the progress
+        />
+      </div>
+    </>
+  );
+};

--- a/src/components/Stage.tsx
+++ b/src/components/Stage.tsx
@@ -1,12 +1,13 @@
 import React, { useState, useEffect } from "react";
-// import "./Stage.css";
 import { StageCard } from "./StageCard";
 import { StageProps, Card } from "../types/types";
+import { RoundTimer } from "./RoundTimer";
 
 export const Stage: React.FC<StageProps> = ({ game }) => {
   // TODO: Check the player poses when the card reaches its final form
   // look into Intersection Observer API (tracks where an object is on the screen)
   const [stageCards, setStageCards] = useState<Card[]>(game.newGame.cardStack);
+  const [roundTimeUp, setRoundTimeUp] = useState<boolean>(false)
   const [activeCard, setActiveCard] = useState<Card>();
 
   useEffect(() => {
@@ -22,41 +23,54 @@ export const Stage: React.FC<StageProps> = ({ game }) => {
     }
   };
 
+  useEffect(() => {
+    if (roundTimeUp === true) {
+        turnCard()
+        console.log("trying to flip card")
+        // setRoundTimeUp(false)
+    }
+  },[roundTimeUp])
+
   return (
     <div
       id="stage"
-      className="flex w-full p-4 bg-orange-600 rounded-xl h-fit"
+      className="flex flex-col w-full pt-4 px-4 bg-orange-500 border-4 border-orange-700 border-solid rounded-xl h-fit"
     >
-      <div
-        id="active-card"
-        className={`mr-16 w-10 h-14 ${
-          activeCard || "border-4 border-black border-dashed rounded-xl"
-        }`}
-        style={{ width: "20vw", height: "25vw" }}
-      >
-        {activeCard ? (
-          <StageCard color={activeCard.color} limbs={activeCard.limbs} />
-        ) : (
-          <> </>
-        )}
+      <div id="cards" className="flex">
+        <div
+          id="active-card"
+          className={`mr-14 w-10 h-14 ${
+            activeCard || "border-4 border-white border-dashed rounded-xl"
+          }`}
+          style={{ width: "20vw", height: "25vw" }}
+        >
+          {activeCard ? (
+            <StageCard active={true} color={activeCard.color} limbs={activeCard.limbs} />
+          ) : (
+            <> </>
+          )}
+        </div>
+        <div
+          id="deck"
+          className="relative flex" // ... like me
+          onClick={() => {
+            turnCard();
+          }}
+        >
+          {game.newGame.cardStack.map((cardItem: Card, i: number) => (
+            <div key={`stage-cards-${i}`}>
+              <StageCard
+                color={cardItem.color}
+                leftOffset={`${i * 10 + 2}px`}
+                z={`${stageCards.length - i}`}
+                limbs={cardItem.limbs}
+              />
+            </div>
+          ))}
+        </div>
       </div>
-      <div
-        id="deck"
-        className="relative flex" // ... like me
-        onClick={() => {
-          turnCard();
-        }}
-      >
-        {game.newGame.cardStack.map((cardItem: Card, i: number) => (
-          <div key={`stage-cards-${i}`}>
-            <StageCard
-              color={cardItem.color}
-              leftOffset={`${i * 10 + 2}px`}
-              z={`${stageCards.length - i}`}
-              limbs={cardItem.limbs}
-            />
-          </div>
-        ))}
+      <div id="round-timer">
+        <RoundTimer setRoundTimeUp={setRoundTimeUp} />
       </div>
     </div>
   );

--- a/src/components/Stage.tsx
+++ b/src/components/Stage.tsx
@@ -4,34 +4,29 @@ import { StageProps, Card } from "../types/types";
 import { RoundTimer } from "./RoundTimer";
 
 export const Stage: React.FC<StageProps> = ({ game }) => {
-  // TODO: Check the player poses when the card reaches its final form
-  // look into Intersection Observer API (tracks where an object is on the screen)
-  // look into framer.com (React animation effects) => { useScroll }
-  const [stageCards, setStageCards] = useState<Card[]>(game.newGame.cardStack);
-  const [roundTimeUp, setRoundTimeUp] = useState<boolean>(false)
-  const [activeCard, setActiveCard] = useState<Card>();
+  const [stageCards, setStageCards] = useState<Card[]>(
+    game.newGame.cardStack.slice(1)
+  );
+  const [activeCard, setActiveCard] = useState<Card>(game.newGame.cardStack[0]);
+  const [activeCardIndex, setActiveCardIndex] = useState<number>(0);
 
-  useEffect(() => {
-    console.log(game);
-  }, []);
-
-  const turnCard = () => {
+  const scoreAndTurnCard = () => {
     if (stageCards.length > 0) {
-      console.log("turning card: " + game.newGame.cardStack[0].color);
-      Rune.actions.checkPlayerPoses()
-      Rune.actions.updateCardStack();
-      setActiveCard(game.newGame.cardStack[0]);
-      // console.log(game)
+      // WHEN THE ROUND ENDS, SCORE THE PREVIOUS CARD'S POSES
+      // Rune.actions.checkPlayerPoses({ index: activeCardIndex });
+      // THEN TURN TO THE NEW CARD (this triggers the useEffect below)
+      setActiveCardIndex((prev) => prev + 1);
     }
   };
 
   useEffect(() => {
-    if (roundTimeUp === true) {
-        turnCard()
-        console.log("trying to flip card")
-        // setRoundTimeUp(false)
+    // TRIGGERED BY THE ACTIVE CARD INDEX CHANGING (skips initial render tho)
+    if (activeCardIndex > 0) {
+      setActiveCard(stageCards[0]);
+      setStageCards((prev) => prev.slice(1));
+      // console.log("after active card removed: " + stageCards.length);
     }
-  },[roundTimeUp])
+  }, [activeCardIndex]);
 
   return (
     <div
@@ -41,13 +36,17 @@ export const Stage: React.FC<StageProps> = ({ game }) => {
       <div id="cards" className="flex">
         <div
           id="active-card"
-          className={`mr-14 w-10 h-14 ${
+          className={`mr-10 w-10 h-14 ${
             activeCard || "border-4 border-white border-dashed rounded-xl"
           }`}
           style={{ width: "20vw", height: "25vw" }}
         >
           {activeCard ? (
-            <StageCard active={true} color={activeCard.color} limbs={activeCard.limbs} />
+            <StageCard
+              active={true}
+              color={activeCard.color}
+              limbs={activeCard.limbs}
+            />
           ) : (
             <> </>
           )}
@@ -55,11 +54,8 @@ export const Stage: React.FC<StageProps> = ({ game }) => {
         <div
           id="deck"
           className="relative flex" // ... like me
-          onClick={() => {
-            turnCard();
-          }}
         >
-          {game.newGame.cardStack.map((cardItem: Card, i: number) => (
+          {stageCards.map((cardItem: Card, i: number) => (
             <div key={`stage-cards-${i}`}>
               <StageCard
                 color={cardItem.color}
@@ -72,7 +68,7 @@ export const Stage: React.FC<StageProps> = ({ game }) => {
         </div>
       </div>
       <div id="round-timer">
-        <RoundTimer setRoundTimeUp={setRoundTimeUp} />
+        <RoundTimer game={game} scoreAndTurnCard={scoreAndTurnCard} activeCardIndex={activeCardIndex} />
       </div>
     </div>
   );

--- a/src/components/Stage.tsx
+++ b/src/components/Stage.tsx
@@ -6,6 +6,7 @@ import { RoundTimer } from "./RoundTimer";
 export const Stage: React.FC<StageProps> = ({ game }) => {
   // TODO: Check the player poses when the card reaches its final form
   // look into Intersection Observer API (tracks where an object is on the screen)
+  // look into framer.com (React animation effects) => { useScroll }
   const [stageCards, setStageCards] = useState<Card[]>(game.newGame.cardStack);
   const [roundTimeUp, setRoundTimeUp] = useState<boolean>(false)
   const [activeCard, setActiveCard] = useState<Card>();
@@ -17,6 +18,7 @@ export const Stage: React.FC<StageProps> = ({ game }) => {
   const turnCard = () => {
     if (stageCards.length > 0) {
       console.log("turning card: " + game.newGame.cardStack[0].color);
+      Rune.actions.checkPlayerPoses()
       Rune.actions.updateCardStack();
       setActiveCard(game.newGame.cardStack[0]);
       // console.log(game)

--- a/src/components/Stage.tsx
+++ b/src/components/Stage.tsx
@@ -1,56 +1,63 @@
 import React, { useState, useEffect } from "react";
 // import "./Stage.css";
 import { StageCard } from "./StageCard";
-import { StageProps, Card } from "../types/types"
+import { StageProps, Card } from "../types/types";
 
 export const Stage: React.FC<StageProps> = ({ game }) => {
-    // TODO: Check the player poses when the card reaches its final form
-    // look into Intersection Observer API (tracks where an object is on the screen)
-    const [stageCards, setStageCards] = useState<Card[]>(game.newGame.cardStack);
-    const [activeCard, setActiveCard] = useState<Card>(game.newGame.cardStack[0]);
+  // TODO: Check the player poses when the card reaches its final form
+  // look into Intersection Observer API (tracks where an object is on the screen)
+  const [stageCards, setStageCards] = useState<Card[]>(game.newGame.cardStack);
+  const [activeCard, setActiveCard] = useState<Card>();
 
-    useEffect(() => {
-        console.log(game)
-    }, []);
+  useEffect(() => {
+    console.log(game);
+  }, []);
 
-    const turnCard = () => {
-        if (stageCards.length > 0) {
-            console.log("turning card: " + game.newGame.cardStack[0].color);
-            Rune.actions.updateCardStack()
-            setActiveCard(game.newGame.cardStack[0])
-            // console.log(game)
-        }
-    };
+  const turnCard = () => {
+    if (stageCards.length > 0) {
+      console.log("turning card: " + game.newGame.cardStack[0].color);
+      Rune.actions.updateCardStack();
+      setActiveCard(game.newGame.cardStack[0]);
+      // console.log(game)
+    }
+  };
 
-    return (
-        <div
-            id="stage"
-            className="flex w-full p-2 bg-orange-600 rounded-b-lg h-fit"
-        >
-            <div
-                id="active-card"
-                className={`mr-2 w-10 h-14 ${activeCard || "border-2 border-black border-dashed rounded-md"}`}
-            >
-                {activeCard && <StageCard color={activeCard.color} />}
-            </div>
-            <div
-                id="deck"
-                className="relative flex" // ... like me
-                onClick={() => {
-                    turnCard();
-                }}
-            >
-                {game.newGame.cardStack.slice(1).map((cardItem:Card, i:number) => (
-                    <div key={`stage-cards-${i}`}>
-                        <StageCard
-                            color={cardItem.color}
-                            leftOffset={`${i * 10 + 2}px`}
-                            z={`${stageCards.length - i}`}
-                            limbs={cardItem.limbs}
-                        />
-                    </div>
-                ))}
-            </div>
-        </div>
-    );
+  return (
+    <div
+      id="stage"
+      className="flex w-full p-4 bg-orange-600 rounded-xl h-fit"
+    >
+      <div
+        id="active-card"
+        className={`mr-16 w-10 h-14 ${
+          activeCard || "border-4 border-black border-dashed rounded-xl"
+        }`}
+        style={{ width: "20vw", height: "25vw" }}
+      >
+        {activeCard ? (
+          <StageCard color={activeCard.color} limbs={activeCard.limbs} />
+        ) : (
+          <> </>
+        )}
+      </div>
+      <div
+        id="deck"
+        className="relative flex" // ... like me
+        onClick={() => {
+          turnCard();
+        }}
+      >
+        {game.newGame.cardStack.map((cardItem: Card, i: number) => (
+          <div key={`stage-cards-${i}`}>
+            <StageCard
+              color={cardItem.color}
+              leftOffset={`${i * 10 + 2}px`}
+              z={`${stageCards.length - i}`}
+              limbs={cardItem.limbs}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
 };

--- a/src/components/StageCard.tsx
+++ b/src/components/StageCard.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 
 type StageCardProps = {
   color: string;
@@ -13,16 +13,24 @@ export const StageCard: React.FC<StageCardProps> = ({
   z,
   limbs,
 }) => {
+  const [colorNicer, setColorNicer] = useState<Record<string,string>>({
+    'red': 'bg-vivid-raspberry',
+    'yellow': 'bg-ronchi',
+    'green': 'bg-willpower-orange',
+    'blue': 'bg-blue-purple',
+    }) 
+  
   return (
     <>
       <div
         id="stage-card"
-        className="absolute w-10 h-14 border-2 border-black rounded-md"
-        style={{ backgroundColor: color, left: leftOffset, zIndex: z }}
+        className= {`absolute w-10 h-14 border-4 border-black rounded-xl ${colorNicer[color]}`}
+        style={{ left: leftOffset , zIndex: z, width: "20vw", height: "25vw" }}
       >
         <div className="bold">
           {limbs && limbs[0]}
           {limbs && limbs[1]}
+          <br />
           {limbs && limbs[2]}
           {limbs && limbs[3]}
           </div>

--- a/src/components/StageCard.tsx
+++ b/src/components/StageCard.tsx
@@ -16,10 +16,10 @@ export const StageCard: React.FC<StageCardProps> = ({
   limbs,
 }) => {
   const [colorNicer, setColorNicer] = useState<Record<string,string>>({
-    'red': 'bg-vivid-raspberry',
+    'pink': 'bg-vivid-raspberry',
     'yellow': 'bg-ronchi',
-    'green': 'bg-willpower-orange',
-    'blue': 'bg-blue-purple',
+    'orange': 'bg-willpower-orange',
+    'purple': 'bg-blue-purple',
     }) 
   
   return (

--- a/src/components/StageCard.tsx
+++ b/src/components/StageCard.tsx
@@ -4,6 +4,7 @@ type StageCardProps = {
   color: string;
   leftOffset?: string;
   z?: string;
+  active?: boolean;
   limbs?: number[];
 };
 
@@ -11,6 +12,7 @@ export const StageCard: React.FC<StageCardProps> = ({
   color,
   leftOffset,
   z,
+  active,
   limbs,
 }) => {
   const [colorNicer, setColorNicer] = useState<Record<string,string>>({
@@ -24,7 +26,7 @@ export const StageCard: React.FC<StageCardProps> = ({
     <>
       <div
         id="stage-card"
-        className= {`absolute w-10 h-14 border-4 border-black rounded-xl ${colorNicer[color]}`}
+        className= {`absolute w-10 h-14 border-4 ${active ? "border-white" : "border-black"} rounded-xl ${colorNicer[color]}`}
         style={{ left: leftOffset , zIndex: z, width: "20vw", height: "25vw" }}
       >
         <div className="bold">

--- a/src/logic.ts
+++ b/src/logic.ts
@@ -3,90 +3,106 @@ import type { GameState, GameActions, Player } from "./types/types";
 import { generateCardStack } from "./util/generateCardStack.ts";
 
 declare global {
-    const Rune: RuneClient<GameState, GameActions>;
+  const Rune: RuneClient<GameState, GameActions>;
 }
 
 export function getCount(game: GameState) {
-    return game.count;
+  return game.count;
 }
 
 Rune.initLogic({
-    minPlayers: 4 /* TEMPORARILY SET TO SHOW AUTOMATICALLY SHOW 4 DEVICES DURING DEVELOPMENT, BUT WILL ULTIMATELY SET TO 1 */,
-    maxPlayers: 4,
-    setup: (playerIds): GameState => {
-        return {
-            count: 0,
-            currentPlayerIndex: 0,
-            remainingTime: 60,
-            cardStack: generateCardStack(10),
-            winner: null,
-            players: playerIds.map((playerId, index) => ({
-                key: playerId,
-                playerId: playerId,
-                limbs: [1, 1, 1, 1],
-                score: 0,
-                displayName: `Player ${index + 1}`,
-            })),
-        };
-    },
-    actions: {
-        /* AS A SECOND ARGUMENT, EACH ACTION GETS ACCESS TO AN OBJECT CONTAINING THE CURRENT GAME STATE, THE PLAYER ID OF THE PLAYER INITIATING THE ACTION, AND AN ARRAY OF ALL PLAYER IDS. */
-        updateCardStack: (_, { game }) => {
-            /* A FUNCTION FOR REMOVING THE TOPMOST CARD FROM THE STACK */
-            game.cardStack.shift();
-        },
+  minPlayers: 4 /* TEMPORARILY SET TO SHOW AUTOMATICALLY SHOW 4 DEVICES DURING DEVELOPMENT, BUT WILL ULTIMATELY SET TO 1 */,
+  maxPlayers: 4,
+  setup: (playerIds): GameState => {
+    return {
+      count: 0,
+      currentPlayerIndex: 0,
+      remainingTime: 60,
+      cardStack: generateCardStack(10),
+      winner: null,
+      players: playerIds.map((playerId, index) => ({
+        key: playerId,
+        playerId: playerId,
+        limbs: [1, 1, 1, 1],
+        score: 0,
+        displayName: `Player ${index + 1}`,
+      })),
+    };
+  },
+  actions: {
+    gameOverSettings: (_, { game }) => {
+      // if (isGameOver(game))
+      const getScores = () =>
+        Object.entries(game.players).reduce((acc, [id, player]) => {
+          acc[id] = player.score;
+          return acc;
+        }, {} as Record<string, number>);
+      // Object.values(game.players).sort((a, b) => b.score - a.score);
 
-        toggleLimb: ({ limb }, { game, playerId: initiatingPlayerId }) => {
-            /* THIS ACTION TAKES A PAYLOAD OBJECT WITH THE LIMB TO BE TOGGLED. EACH LIMB HAS THREE STATES TO TOGGLE BETWEEN */
-            const playerIndex = game.players.findIndex((player: Player) => player.playerId === initiatingPlayerId);
-            const currentPose = game.players[playerIndex].limbs[limb];
-            const newPose = (currentPose % 3) + 1;
-            game.players[playerIndex].limbs[limb] = newPose;
-        },
-        checkPlayerPoses: ({ index }, { game }) => {
-            /* COMPARE LIMBS OF EACH PLAYER AGAINST FRONTMOST CARD IN CARDSTACK, THEN UPDATES SCORE PROPERTY FOR EACH PLAYER */
-            game.players.forEach((player: Player) => {
-                const activeCard = game.cardStack[index];
-                const playerLimbPoses = player.limbs;
-                // const playerScore = player.score;
+      Rune.gameOver({
+        players: getScores(),
+        delayPopUp: true,
+      });
+    },
+    /* AS A SECOND ARGUMENT, EACH ACTION GETS ACCESS TO AN OBJECT CONTAINING THE CURRENT GAME STATE, THE PLAYER ID OF THE PLAYER INITIATING THE ACTION, AND AN ARRAY OF ALL PLAYER IDS. */
+    updateCardStack: (_, { game }) => {
+      /* A FUNCTION FOR REMOVING THE TOPMOST CARD FROM THE STACK */
+      game.cardStack.shift();
+    },
 
-                const score = playerLimbPoses.reduce((acc, limbPose, i) => {
-                    if (limbPose === activeCard.limbs[i]) {
-                        return acc + 1;
-                    } else {
-                        return acc;
-                    }
-                }, 0);
+    toggleLimb: ({ limb }, { game, playerId: initiatingPlayerId }) => {
+      /* THIS ACTION TAKES A PAYLOAD OBJECT WITH THE LIMB TO BE TOGGLED. EACH LIMB HAS THREE STATES TO TOGGLE BETWEEN */
+      const playerIndex = game.players.findIndex(
+        (player: Player) => player.playerId === initiatingPlayerId
+      );
+      const currentPose = game.players[playerIndex].limbs[limb];
+      const newPose = (currentPose % 3) + 1;
+      game.players[playerIndex].limbs[limb] = newPose;
+    },
+    checkPlayerPoses: ({ index }, { game }) => {
+      /* COMPARE LIMBS OF EACH PLAYER AGAINST FRONTMOST CARD IN CARDSTACK, THEN UPDATES SCORE PROPERTY FOR EACH PLAYER */
+      game.players.forEach((player: Player) => {
+        const activeCard = game.cardStack[index];
+        const playerLimbPoses = player.limbs;
+        // const playerScore = player.score;
 
-                player.score = player.score + score;
-                // console.log(
-                //     "player:",
-                //     player.displayName,
-                //     "correct",
-                //     frontmostCard.limbs,
-                //     "pose",
-                //     playerLimbPoses,
-                //     "score",
-                //     score,
-                //     "Accumulated Score",
-                //     playerScore
-                // );
-            });
-        },
+        const score = playerLimbPoses.reduce((acc, limbPose, i) => {
+          if (limbPose === activeCard.limbs[i]) {
+            return acc + 1;
+          } else {
+            return acc;
+          }
+        }, 0);
+
+        player.score = player.score + score;
+        // console.log(
+        //     "player:",
+        //     player.displayName,
+        //     "correct",
+        //     frontmostCard.limbs,
+        //     "pose",
+        //     playerLimbPoses,
+        //     "score",
+        //     score,
+        //     "Accumulated Score",
+        //     playerScore
+        // );
+      });
     },
-    events: {
-        playerJoined: () => {
-            // Handle player joined
-        },
-        playerLeft() {
-            // Handle player left
-        },
+  },
+  events: {
+    playerJoined: () => {
+      // Handle player joined
     },
-    update: ({ game }) => {
-        /* THIS UPDATE FUNCTION RUNS EVERY 1 SECOND */
-        /* GAME OVER AFTER 60 SECONDS */
-        const timeElapsed = Rune.gameTimeInSeconds();
-        game.remainingTime = 60 - timeElapsed;
-        game.remainingTime === 0 && Rune.gameOver();
+    playerLeft() {
+      // Handle player left
     },
+  },
+  update: ({ game }) => {
+    /* THIS UPDATE FUNCTION RUNS EVERY 1 SECOND */
+    /* GAME OVER AFTER 60 SECONDS */
+    const timeElapsed = Rune.gameTimeInSeconds();
+    game.remainingTime = 60 - timeElapsed;
+    game.remainingTime === 0 && Rune.actions.gameOverSettings();
+  },
 });

--- a/src/logic.ts
+++ b/src/logic.ts
@@ -30,21 +30,11 @@ Rune.initLogic({
     };
   },
   actions: {
-    startGameOverProcess: (_, { game }) => {
-        // DOES NOT WORK (error: cannot read properties of undefined (reading 'randomSeed'))
-        const getScores = () =>
-        Object.entries(game.players).reduce((acc, [id, player]) => {
-            acc[id] = player.score;
-            return acc;
-        }, {} as Record<string, number>);
-        // Object.values(game.players).sort((a, b) => b.score - a.score);
-        
-      Rune.gameOver({
-        players: getScores(),
-        delayPopUp: true,
-      });
+    testFunction: (_, { game }) => {
+      console.log(game.players[0].score)
+      console.log(game.players[1])
     },
-    
+
     /* AS A SECOND ARGUMENT, EACH ACTION GETS ACCESS TO AN OBJECT CONTAINING THE CURRENT GAME STATE, THE PLAYER ID OF THE PLAYER INITIATING THE ACTION, AND AN ARRAY OF ALL PLAYER IDS. */
     updateCardStack: (_, { game }) => {
       /* A FUNCTION FOR REMOVING THE TOPMOST CARD FROM THE STACK */
@@ -104,6 +94,16 @@ Rune.initLogic({
     /* GAME OVER AFTER 60 SECONDS */
     const timeElapsed = Rune.gameTimeInSeconds();
     game.remainingTime = 60 - timeElapsed;
-    game.remainingTime === 0 && Rune.actions.startGameOverProcess();
+    if (game.remainingTime === 0) {
+      Rune.gameOver({
+        players: {
+          [game.players[0].playerId]: game.players[0].score,
+          [game.players[1].playerId]: game.players[1].score,
+          [game.players[2].playerId]: game.players[2].score,
+          [game.players[3].playerId]: game.players[3].score,
+        },
+        delayPopUp: false,
+      });
+    }
   },
 });

--- a/src/logic.ts
+++ b/src/logic.ts
@@ -30,20 +30,21 @@ Rune.initLogic({
     };
   },
   actions: {
-    gameOverSettings: (_, { game }) => {
-      // DOES NOT WORK
-      const getScores = () =>
+    startGameOverProcess: (_, { game }) => {
+        // DOES NOT WORK (error: cannot read properties of undefined (reading 'randomSeed'))
+        const getScores = () =>
         Object.entries(game.players).reduce((acc, [id, player]) => {
-          acc[id] = player.score;
-          return acc;
+            acc[id] = player.score;
+            return acc;
         }, {} as Record<string, number>);
-      // Object.values(game.players).sort((a, b) => b.score - a.score);
-
+        // Object.values(game.players).sort((a, b) => b.score - a.score);
+        
       Rune.gameOver({
         players: getScores(),
         delayPopUp: true,
       });
     },
+    
     /* AS A SECOND ARGUMENT, EACH ACTION GETS ACCESS TO AN OBJECT CONTAINING THE CURRENT GAME STATE, THE PLAYER ID OF THE PLAYER INITIATING THE ACTION, AND AN ARRAY OF ALL PLAYER IDS. */
     updateCardStack: (_, { game }) => {
       /* A FUNCTION FOR REMOVING THE TOPMOST CARD FROM THE STACK */
@@ -103,6 +104,6 @@ Rune.initLogic({
     /* GAME OVER AFTER 60 SECONDS */
     const timeElapsed = Rune.gameTimeInSeconds();
     game.remainingTime = 60 - timeElapsed;
-    game.remainingTime === 0 && Rune.actions.gameOverSettings();
+    game.remainingTime === 0 && Rune.actions.startGameOverProcess();
   },
 });

--- a/src/logic.ts
+++ b/src/logic.ts
@@ -31,7 +31,7 @@ Rune.initLogic({
   },
   actions: {
     gameOverSettings: (_, { game }) => {
-      // if (isGameOver(game))
+      // DOES NOT WORK
       const getScores = () =>
         Object.entries(game.players).reduce((acc, [id, player]) => {
           acc[id] = player.score;

--- a/src/logic.ts
+++ b/src/logic.ts
@@ -17,7 +17,7 @@ Rune.initLogic({
         return {
             count: 0,
             currentPlayerIndex: 0,
-            remainingTime: 0,
+            remainingTime: 60,
             cardStack: generateCardStack(10),
             winner: null,
             players: playerIds.map((playerId, index) => ({
@@ -43,15 +43,15 @@ Rune.initLogic({
             const newPose = (currentPose % 3) + 1;
             game.players[playerIndex].limbs[limb] = newPose;
         },
-        checkPlayerPoses: (_, { game }) => {
+        checkPlayerPoses: ({ index }, { game }) => {
             /* COMPARE LIMBS OF EACH PLAYER AGAINST FRONTMOST CARD IN CARDSTACK, THEN UPDATES SCORE PROPERTY FOR EACH PLAYER */
             game.players.forEach((player: Player) => {
-                const frontmostCard = game.cardStack[0];
+                const activeCard = game.cardStack[index];
                 const playerLimbPoses = player.limbs;
-                const playerScore = player.score;
+                // const playerScore = player.score;
 
-                const score = playerLimbPoses.reduce((acc, limbPose, index) => {
-                    if (limbPose === frontmostCard.limbs[index]) {
+                const score = playerLimbPoses.reduce((acc, limbPose, i) => {
+                    if (limbPose === activeCard.limbs[i]) {
                         return acc + 1;
                     } else {
                         return acc;
@@ -82,11 +82,11 @@ Rune.initLogic({
             // Handle player left
         },
     },
-    // update: ({ game }) => {
-    //     /* THIS UPDATE FUNCTION RUNS EVERY 1 SECOND */
-    //     /* GAME OVER AFTER 60 SECONDS */
-    //     const timeElapsed = Rune.gameTimeInSeconds();
-    //     game.remainingTime = 60 - timeElapsed;
-    //     game.remainingTime === 0 && Rune.gameOver();
-    // },
+    update: ({ game }) => {
+        /* THIS UPDATE FUNCTION RUNS EVERY 1 SECOND */
+        /* GAME OVER AFTER 60 SECONDS */
+        const timeElapsed = Rune.gameTimeInSeconds();
+        game.remainingTime = 60 - timeElapsed;
+        game.remainingTime === 0 && Rune.gameOver();
+    },
 });

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -55,7 +55,7 @@ export interface GameState {
 }
 
 export type GameActions = {
-    startGameOverProcess: () => void;
+    testFunction: () => void;
     updateCardStack: () => void;
     toggleLimb: (params: { limb: LimbEnum }) => void;
     checkPlayerPoses: (params: { index: number }) => void;
@@ -63,6 +63,7 @@ export type GameActions = {
 
 export type CharacterProps = {
     player: Player;
+    playerName: string;
 };
 
 export type LimbProps = {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -55,6 +55,7 @@ export interface GameState {
 }
 
 export type GameActions = {
+    gameOverSettings: () => void;
     updateCardStack: () => void;
     toggleLimb: (params: { limb: LimbEnum }) => void;
     checkPlayerPoses: (params: { index: number }) => void;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -55,7 +55,7 @@ export interface GameState {
 }
 
 export type GameActions = {
-    gameOverSettings: () => void;
+    startGameOverProcess: () => void;
     updateCardStack: () => void;
     toggleLimb: (params: { limb: LimbEnum }) => void;
     checkPlayerPoses: (params: { index: number }) => void;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -21,6 +21,12 @@ export type StageProps = {
     game: any;
 };
 
+export type RoundTimerProps = {
+    scoreAndTurnCard:Function;
+    game: any;
+    activeCardIndex: number;
+}
+
 export enum LimbPose {
     Straight = 1,
     BentUp = 2,
@@ -51,7 +57,7 @@ export interface GameState {
 export type GameActions = {
     updateCardStack: () => void;
     toggleLimb: (params: { limb: LimbEnum }) => void;
-    checkPlayerPoses: () => void;
+    checkPlayerPoses: (params: { index: number }) => void;
 };
 
 export type CharacterProps = {

--- a/src/util/generateCardStack.ts
+++ b/src/util/generateCardStack.ts
@@ -7,7 +7,7 @@ const getRandomNumber = (min: number, max: number): number => {
 
 /* GENERATES AN ARRAY OF CARD OBJECTS. THE CARD OBJECT CONISTS OF A COLOR AND LIMBS ARRAY */
 export const generateCardStack = (totalCards: number): Card[] => {
-    const colors = ["red", "green", "yellow", "blue"];
+    const colors = ["pink", "yellow", "orange", "purple"];
     const stack: Card[] = [];
     for (let i = 0; i < totalCards; i++) {
         const randomIndex = Math.floor(Math.random() * colors.length);


### PR DESCRIPTION
These changes create a round timer that visually fills in every second and separates the rounds by 6 seconds. At the top of each round, it scores the last round with the Rune action checkPlayerPoses and turns the top card over to start a new round. Currently it checks player poses 4 times (not intentional).